### PR TITLE
fix operator precedence issue in safe_config_val

### DIFF
--- a/contrib/apelscripts/condor_batch.sh
+++ b/contrib/apelscripts/condor_batch.sh
@@ -16,10 +16,7 @@ yesterday=$(date -u --date='00:00:00 yesterday' +%s)
 OUTPUT_DIR="$(condor_ce_config_val APEL_OUTPUT_DIR)"
 OUTPUT_FILE="$OUTPUT_DIR/batch-$(date -u --date='yesterday' +%Y%m%d )-$(hostname -s)"
 
-if [ ! -d $OUTPUT_DIR ] || [ ! -w $OUTPUT_DIR ]; then
-    echo "Cannot write to $OUTPUT_DIR"
-    exit 1
-fi
+[[ -d $OUTPUT_DIR && -w $OUTPUT_DIR ]] || fail "Cannot write to $OUTPUT_DIR"
 
 # Build the filter for the history command
 CONSTR="EnteredCurrentStatus >= $yesterday && EnteredCurrentStatus < $today && RemoteWallclockTime !=0"

--- a/contrib/apelscripts/condor_batch.sh
+++ b/contrib/apelscripts/condor_batch.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
+fail () {
+    echo "$@" >&2
+    exit 1
+}
+
 safe_config_val () {
-    condor_ce_config_val $1 || echo "Failed to retrieve CE configuration value '$1'" && exit 1
+    condor_ce_config_val $1 || fail "Failed to retrieve CE configuration value '$1'"
 }
 
 # Create a temporary accounting file name


### PR DESCRIPTION
`exit 1` ends up being called for both success and failure